### PR TITLE
docs: update for blink.cmp 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ Ripgrep source for [blink.cmp](https://github.com/Saghen/blink.cmp).
 ```lua
 require("blink.cmp").setup({
 	sources = {
+		completion = {
+			enabled_providers = { "lsp", "path", "snippets", "buffer", "ripgrep" }, -- add "rg" here
+		},
 		providers = {
-			{
-				"blink-cmp-rg",
-				name = "Rg",
+			ripgrep = {
+				module = "blink-cmp-rg",
+				name = "Ripgrep",
 				-- options below are optional, these are the default values
 				opts = {
 					prefix_min_len = 3,


### PR DESCRIPTION
the `sources` configuration changed for blink.cmp 0.4, so that the documented configuration does not work anymore. This PR updates the config to work with 0.4.