### PR TITLE
fix: issues with default `rg` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ require("blink.cmp").setup({
 					get_command = function(context, prefix)
 						return {
 							"rg",
-							"--heading",
+							"--no-config",
 							"--json",
 							"--word-regexp",
-							"--color",
-							"never",
-							"-i",
+							"--case-sensitive",
+							"--",
 							prefix .. "[\\w_-]+",
 							vim.fs.root(0, "git") or vim.fn.getcwd(),
 						}

--- a/lua/blink-cmp-rg/init.lua
+++ b/lua/blink-cmp-rg/init.lua
@@ -10,7 +10,7 @@ function RgSource.new(opts)
 				"--no-config",
 				"--json",
 				"--word-regexp",
-				"--case-sensitive",
+				"--ignore-case",
 				"--",
 				prefix .. "[\\w_-]+",
 				vim.fs.root(0, "git") or vim.fn.getcwd(),

--- a/lua/blink-cmp-rg/init.lua
+++ b/lua/blink-cmp-rg/init.lua
@@ -7,12 +7,11 @@ function RgSource.new(opts)
 		get_command = opts.get_command or function(_, prefix)
 			return {
 				"rg",
-				"--heading",
+				"--no-config",
 				"--json",
 				"--word-regexp",
-				"--color",
-				"never",
-				"-i",
+				"--case-sensitive",
+				"--",
 				prefix .. "[\\w_-]+",
 				vim.fs.root(0, "git") or vim.fn.getcwd(),
 			}


### PR DESCRIPTION
- Use `--` to properly escape the search query, this prevents issues
  with queries starting with a dash.
- Remove `--color=never` and `--heading`, since `--json` already takes
  care of that.
- Add `--no-config` to prevent unexpected interference with a user's
  `RIPGREP_CONFIG_PATH`.
- Use `--ignore-case` instead of `-i` for verbosity.
