### PR TITLE
fix: use .git instead of git directory as the root

### DIFF
--- a/lua/blink-cmp-rg/init.lua
+++ b/lua/blink-cmp-rg/init.lua
@@ -14,7 +14,7 @@ function RgSource.new(opts)
 				"--ignore-case",
 				"--",
 				prefix .. "[\\w_-]+",
-				vim.fs.root(0, "git") or vim.fn.getcwd(),
+				vim.fs.root(0, ".git") or vim.fn.getcwd(),
 			}
 		end,
 		get_prefix = opts.get_prefix or function(_)


### PR DESCRIPTION
On my system, I keep my git repositories in `~/git/`. The default configuration seemed to be looking for matches in all of my local projects instead of just the current project.