### PR TITLE
perf: remove extra map/filter in RgSource:get_completions

### DIFF
--- a/lua/blink-cmp-rg/init.lua
+++ b/lua/blink-cmp-rg/init.lua
@@ -45,13 +45,12 @@ function RgSource:get_completions(context, resolve)
 		vim.iter(lines)
 			:map(function(line)
 				local ok, item = pcall(vim.json.decode, line)
-				return ok and item or {}
-			end)
-			:filter(function(item)
-				return item.type == "match"
-			end)
-			:map(function(item)
-				return item.data.submatches
+				item = ok and item or {}
+				if item.type == "match" then
+					return item.data.submatches
+				else
+					return {}
+				end
 			end)
 			:flatten()
 			:each(function(submatch)


### PR DESCRIPTION
This should be a mini improvement. I think it will iterate all matches one less times, which might offer a performance boost when there are many matches.